### PR TITLE
fix error handling for database update

### DIFF
--- a/scripts/updatedb.js
+++ b/scripts/updatedb.js
@@ -8,7 +8,8 @@ if(!process.env.npm_package_config_update){
 
 var cp = require('child_process');
 var fs = require('fs');
-var http = require('https');
+var http = require('http');
+var https = require('https');
 var path = require('path');
 var url = require('url');
 var zlib = require('zlib');
@@ -114,7 +115,7 @@ Host: url.parse(downloadUrl).host
 
     mkdir(tmpFile);
 
-    var client = http.get(getOptions(), onResponse);
+    var client = https.get(getOptions(), onResponse);
 
     process.stdout.write('Retrieving ' + fileName + ' ...');
 }


### PR DESCRIPTION
At one time the module `http` was switched for `https`, which broke the error handler since it is not a 100% replacement.